### PR TITLE
spires: missing operator addition

### DIFF
--- a/invenio_query_parser/contrib/spires/walkers/spires_to_invenio.py
+++ b/invenio_query_parser/contrib/spires/walkers/spires_to_invenio.py
@@ -79,6 +79,10 @@ class SpiresToInvenio(object):
     def visit(self, node):
         return type(node)(node.value)
 
+    @visitor(ast.ValueQuery)
+    def visit(self, node, op):
+        return type(node)(op)
+
     @visitor(ast.SingleQuotedValue)
     def visit(self, node):
         return type(node)(node.value)
@@ -88,6 +92,10 @@ class SpiresToInvenio(object):
         return type(node)(node.value)
 
     @visitor(ast.RegexValue)
+    def visit(self, node):
+        return type(node)(node.value)
+
+    @visitor(ast.EmptyQuery)
     def visit(self, node):
         return type(node)(node.value)
 


### PR DESCRIPTION
* Adds missing operator for the spires_to_invenio walker.

Co-authored-by: Jiri Kuncar <jiri.kuncar@cern.ch>
Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>