### PR TITLE
parser: 'not' functionality on parser

### DIFF
--- a/invenio_query_parser/parser.py
+++ b/invenio_query_parser/parser.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio-Query-Parser.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio-Query-Parser is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -25,11 +25,10 @@
 
 from __future__ import absolute_import
 
-import pypeg2
 import re
 
-from pypeg2 import (Keyword, maybe_some, optional, attr,
-                    Literal, omit, some)
+import pypeg2
+from pypeg2 import Keyword, Literal, attr, maybe_some, omit, optional, some
 
 from . import ast
 from ._compat import string_types
@@ -235,6 +234,7 @@ class AndQuery(UnaryRule):
         (
             omit(And),
             [
+                (omit(Whitespace), attr('op', NotQuery)),
                 (omit(Whitespace), attr('op', SimpleQuery)),
                 (omit(_), attr('op', ParenthesizedQuery)),
             ],
@@ -248,6 +248,7 @@ class AndQuery(UnaryRule):
 
 class ImplicitAndQuery(UnaryRule):
     grammar = [
+        attr('op', NotQuery),
         attr('op', ParenthesizedQuery),
         attr('op', SimpleQuery),
     ]
@@ -258,6 +259,7 @@ class OrQuery(UnaryRule):
         (
             omit(Or),
             [
+                (omit(Whitespace), attr('op', NotQuery)),
                 (omit(Whitespace), attr('op', SimpleQuery)),
                 (omit(_), attr('op', ParenthesizedQuery)),
             ],
@@ -271,13 +273,13 @@ class OrQuery(UnaryRule):
 
 Query.grammar = attr('children', (
     [
+        NotQuery,
         ParenthesizedQuery,
         SimpleQuery,
     ],
     maybe_some((
         omit(_),
         [
-            NotQuery,
             AndQuery,
             OrQuery,
             ImplicitAndQuery,

--- a/invenio_query_parser/walkers/pypeg_to_ast.py
+++ b/invenio_query_parser/walkers/pypeg_to_ast.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio-Query-Parser.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Invenio-Query-Parser is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -110,7 +110,7 @@ class PypegConverter(object):
 
     @visitor(parser.NotQuery)
     def visit(self, node, child):
-        return ast.AndOp(None, ast.NotOp(child))
+        return ast.NotOp(child)
 
     @visitor(parser.AndQuery)
     def visit(self, node, child):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -250,6 +250,35 @@ class TestParser(object):
                            ValueQuery(Value('bbb'))),
                      NotOp(ValueQuery(Value('ccc')))),
                ValueQuery(Value('ddd')))),
+        ("foo:bar not foo:bar",
+            AndOp(
+                KeywordOp(Keyword('foo'), Value('bar')),
+                NotOp(KeywordOp(Keyword('foo'), Value('bar'))))),
+        ("foo:bar and -foo:bar",
+            AndOp(
+                KeywordOp(Keyword('foo'), Value('bar')),
+                NotOp(KeywordOp(Keyword('foo'), Value('bar'))))),
+        ("-foo:bar",
+            NotOp(KeywordOp(Keyword('foo'), Value('bar')))),
+        ("-foo",
+            NotOp(ValueQuery(Value('foo')))),
+        ("foo:bar or -foo:bar",
+            OrOp(
+                KeywordOp(Keyword('foo'), Value('bar')),
+                NotOp(KeywordOp(Keyword('foo'), Value('bar'))))),
+        ("foo:bar or not foo:bar",
+            OrOp(
+                KeywordOp(Keyword('foo'), Value('bar')),
+                NotOp(KeywordOp(Keyword('foo'), Value('bar'))))),
+        ("bar + (not foo:\"Ba, r\")",
+            AndOp(
+                ValueQuery(Value('bar')),
+                NotOp(KeywordOp(Keyword('foo'), DoubleQuotedValue('Ba, r'))))),
+        ("bar | -foo:bar",
+            OrOp(
+                ValueQuery(Value('bar')),
+                NotOp(KeywordOp(Keyword('foo'), Value('bar'))))),
+
 
         # Nested searches
         ("refersto:author:Ellis",


### PR DESCRIPTION
* FIXES Fixes 'not' functionality on the parser.

* Adds test cases with queries using 'not'.
  (closes #24)

Signed-off-by: Panos Paparrigopoulos <panos.paparrigopoulos@cern.ch>