### PR TITLE
walkers: match unit: key error fix

### DIFF
--- a/invenio_query_parser/walkers/match_unit.py
+++ b/invenio_query_parser/walkers/match_unit.py
@@ -42,7 +42,7 @@ def dottable_getitem(data, dottable_key, default=None):
         elif len(keys) == 1:
             key = keys[0]
             if isinstance(value, MutableMapping):
-                return value[key]
+                return value.get(key, default)
             elif isinstance(value, MutableSequence):
                 return [getitem(v, key) for v in value]
             return default

--- a/tests/test_walkers.py
+++ b/tests/test_walkers.py
@@ -315,6 +315,7 @@ class TestMatchUnit(object):
         ('title:"Test"', {'title': 'Test'}, True),
         ('title:"Test"', {'title': 'NoTest'}, False),
         ('title:Test', {'title': 'My Testing'}, True),
+        ('non_existing:Test', {'title': 'My Testing'}, False),
 
         # Test list matching
         ('author:Ellis',


### PR DESCRIPTION
* BETTER Default key getter returns default value instead of raising key
  error if the key is not found inside the dictionary.

Signed-off-by: Esteban J. G. Gabancho <esteban.gabancho@gmail.com>