### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,10 +24,10 @@ Authors
 =======
 
 Invenio-Query-Parser is developed for the `Invenio
-<http://invenio-software.org>`_ digital library software.
+<http://inveniosoftware.org>`_ digital library software.
 
-Contact us at `info@invenio-software.org
-<mailto:info@invenio-software.org>`_.
+Contact us at `info@inveniosoftware.org
+<mailto:info@inveniosoftware.org>`_.
 
 - Alessio Deiana <https://github.com/osso>
 - Federico Poli <https://github.com/fpoli>

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -31,8 +31,8 @@ Documentation
 Happy hacking and thanks for flying Invenio-Query-Parser.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-query-parser
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     url='https://github.com/inveniosoftware/invenio-query-parser',
     license='GPLv2',
     author='Invenio collaboration',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     description='Search query parser supporting Invenio and SPIRES '
         'search syntax.',
     long_description=__doc__,


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>